### PR TITLE
feat: add csharp support via csc direct compilation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ChangeLogs
 
+## `v1.0.6`
+
+- feat: add `csharp` support (via `csc` direct compilation, includes Android GC heap workaround for `dotnet` runtime)
+
 ## `v1.0.5`
 
 - feat: add `dart` support

--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
   "id": "acode.runner.plugin",
   "name": "Runner",
   "main": "main.js",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "repository": "https://github.com/Acode-Foundation/acode-runner-plugin.git",
   "icon": "icon.png",
   "minVersionCode": 963,

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ A powerful code runner plugin for Acode that adds a **play button** to execute d
 | **Python**       | `.py`, `.pyw`                 | ✅     |
 | **C**            | `.c`                          | ✅     |
 | **C++**          | `.cpp`, `.cxx`, `.cc`, `.c++` | ✅     |
+| **C#**           | `.cs`                         | ✅     |
 | **Java**         | `.java`                       | ✅     |
 | **Go**           | `.go`                         | ✅     |
 | **PHP**          | `.php`                        | ✅     |

--- a/src/languageRunners.js
+++ b/src/languageRunners.js
@@ -50,6 +50,19 @@ export default class LanguageRunners {
 			description: 'C++ compiler'
 		});
 
+        // C#
+        this.#runners.set('csharp', {
+            extensions: ['cs'],
+            commands: [
+                {
+                    cmd: `mkdir -p /tmp/csrun_{name} && cd /tmp/csrun_{name} && cp "{file}" ./Program.cs && export DOTNET_gcServer=0 DOTNET_GCHeapHardLimit=0x10000000 DOTNET_GCgen0size=0x2000000 && CSC=$(find /usr/lib/dotnet/sdk -name "csc.dll" 2>/dev/null | head -1) && REFDIR=$(find /usr/lib/dotnet/packs/Microsoft.NETCore.App.Ref -type d -name "net8.0" 2>/dev/null | head -1) && REFS=$(find "$REFDIR" -name "*.dll" 2>/dev/null | sed 's/^/-r:/' | tr '\n' ' ') && ([ -f Program.runtimeconfig.json ] || printf '{"runtimeOptions":{"tfm":"net8.0","framework":{"name":"Microsoft.NETCore.App","version":"8.0.0"}}}' > Program.runtimeconfig.json) && ([ -f GlobalUsings.cs ] || printf 'global using System;\\nglobal using System.Collections.Generic;\\nglobal using System.Linq;\\nglobal using System.IO;\\nglobal using System.Threading.Tasks;\\n' > GlobalUsings.cs) && dotnet exec "$CSC" -nologo -optimize -langversion:latest $REFS -out:Program.dll Program.cs GlobalUsings.cs && dotnet Program.dll`,
+                    packages: ['dotnet8-sdk'],
+                    checkCommand: 'dotnet'
+                }
+            ],
+            description: 'C# compiler'
+        });
+        
 		// Java
 		this.#runners.set('java', {
 			extensions: ['java'],

--- a/src/languageRunners.js
+++ b/src/languageRunners.js
@@ -51,17 +51,17 @@ export default class LanguageRunners {
 		});
 
         // C#
-        this.#runners.set('csharp', {
-            extensions: ['cs'],
-            commands: [
-                {
-                    cmd: `mkdir -p /tmp/csrun_{name} && cd /tmp/csrun_{name} && cp "{file}" ./Program.cs && export DOTNET_gcServer=0 DOTNET_GCHeapHardLimit=0x10000000 DOTNET_GCgen0size=0x2000000 && CSC=$(find /usr/lib/dotnet/sdk -name "csc.dll" 2>/dev/null | head -1) && REFDIR=$(find /usr/lib/dotnet/packs/Microsoft.NETCore.App.Ref -type d -name "net8.0" 2>/dev/null | head -1) && REFS=$(find "$REFDIR" -name "*.dll" 2>/dev/null | sed 's/^/-r:/' | tr '\n' ' ') && ([ -f Program.runtimeconfig.json ] || printf '{"runtimeOptions":{"tfm":"net8.0","framework":{"name":"Microsoft.NETCore.App","version":"8.0.0"}}}' > Program.runtimeconfig.json) && ([ -f GlobalUsings.cs ] || printf 'global using System;\\nglobal using System.Collections.Generic;\\nglobal using System.Linq;\\nglobal using System.IO;\\nglobal using System.Threading.Tasks;\\n' > GlobalUsings.cs) && dotnet exec "$CSC" -nologo -optimize -langversion:latest $REFS -out:Program.dll Program.cs GlobalUsings.cs && dotnet Program.dll`,
-                    packages: ['dotnet8-sdk'],
-                    checkCommand: 'dotnet'
-                }
-            ],
-            description: 'C# compiler'
-        });
+		this.#runners.set('csharp', {
+			extensions: ['cs'],
+			commands: [
+				{
+					cmd: `mkdir -p /tmp/csrun_{name} && cd /tmp/csrun_{name} && cp "{path}" ./Program.cs && export DOTNET_gcServer=0 DOTNET_GCHeapHardLimit=0x10000000 DOTNET_GCgen0size=0x2000000 && CSC=$(find /usr/lib/dotnet/sdk -name "csc.dll" 2>/dev/null | head -1) && REFDIR=$(find /usr/lib/dotnet/packs/Microsoft.NETCore.App.Ref -type d -name "net8.0" 2>/dev/null | head -1) && REFS=$(find "$REFDIR" -name "*.dll" 2>/dev/null | sed 's/^/-r:/' | tr '\n' ' ') && ([ -f Program.runtimeconfig.json ] || printf '{"runtimeOptions":{"tfm":"net8.0","framework":{"name":"Microsoft.NETCore.App","version":"8.0.0"}}}' > Program.runtimeconfig.json) && ([ -f GlobalUsings.cs ] || printf 'global using System;\\nglobal using System.Collections.Generic;\\nglobal using System.Linq;\\nglobal using System.IO;\\nglobal using System.Threading.Tasks;\\n' > GlobalUsings.cs) && dotnet exec "$CSC" -nologo -optimize -langversion:latest $REFS -out:Program.dll Program.cs GlobalUsings.cs && dotnet Program.dll`,
+					packages: ['dotnet8-sdk'],
+					checkCommand: 'dotnet'
+				}
+			],
+			description: 'C# compiler'
+		});
         
 		// Java
 		this.#runners.set('java', {


### PR DESCRIPTION
- Uses csc (Roslyn compiler) instead of dotnet run for faster execution
- Includes DOTNET_GCHeapHardLimit workaround for Android memory constraints
- Generates GlobalUsings.cs to match dotnet new console's implicit usings
- Caches Program.runtimeconfig.json per project to avoid regeneration